### PR TITLE
Move requirements to setup.py file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "setup.py" }}
+          key: v1-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Install dependencies
           command: |
@@ -16,9 +15,9 @@ jobs:
             . venv/bin/activate
             python setup.py develop
       - save_cache:
+          key: v1-dependencies-{{ checksum "setup.py" }}
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Run tests
           command: |
@@ -29,7 +28,11 @@ jobs:
           path: test-reports
           destination: test-reports
   deploy:
-    - steps:
+    docker:
+      - image: circleci/python:3.6.1
+    working_directory: ~/repo
+    steps:
+      - checkout
       - run:
           name: Init .pypirc
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,12 @@ workflows:
               only: master
   test_and_deploy:
     jobs:
-      - test
+      - test:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+.\d+.\d+$/
       - deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only: master
+              ignore: master
   test_and_deploy:
     jobs:
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
       - test:
           filters:
             tags:
-              ignore: *
+              ignore: /.*/
             branches:
               only: master
   test_and_deploy:
@@ -68,4 +68,4 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
             branches:
-              ignore: *
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            python setup.py develop
+            pip install -e .[develop]
       - save_cache:
           key: v1-dependencies-{{ checksum "setup.py" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,22 @@ jobs:
             twine upload dist/*
 workflows:
   version: 2
-  build_and_deploy:
+  test:
+    jobs:
+      - test:
+          filters:
+            tags:
+              ignore: *
+            branches:
+              only: master
+  test_and_deploy:
     jobs:
       - test:
       - deploy:
           requires:
-            - build
+            - test
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
             branches:
-              only: master
+              ignore: *

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
               only: master
   test_and_deploy:
     jobs:
-      - test:
+      - test
       - deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,22 +8,21 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v1-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Install dependencies
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            python setup.py develop
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
-            pip install --editable .
             pytest --cov mortgage
             bash <(curl -s https://codecov.io/bash)
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip setuptools
             pip install -e .[develop]
       - save_cache:
           key: v1-dependencies-{{ checksum "setup.py" }}

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-cov
-bumpversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-bumpversion==0.5.3
-coverage==4.4.1
-py==1.4.34
-pytest==3.2.1
-pytest-cov==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,11 @@ setup(
     zip_safe=False,
     keywords='mortgage',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests'
 )

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     README = readme_file.read()
 
-with open('requirements.txt') as file:
-    REQUIREMENTS = file.read()
-
 setup(
     name='mortgage',
     version='1.0.1',
@@ -15,7 +12,10 @@ setup(
     author_email='austin.s.mcconnell@gmail.com',
     url='https://github.com/austinmcconnell/mortgage',
     packages=find_packages(exclude='tests'),
-    install_requires=REQUIREMENTS,
+    install_requires=[],
+    extras_require={
+        'develop': ['pytest', 'pytest-cov', 'bumpversion']
+    },
     license='MIT license',
     zip_safe=False,
     keywords='mortgage',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ setup(
     packages=find_packages(exclude='tests'),
     install_requires=[],
     extras_require={
-        'develop': ['pytest', 'pytest-cov', 'bumpversion']
+        'develop': ['pytest>=3.2.1,<4.0.0',
+                    'pytest-cov>=2.5.1,<3.0.0',
+                    'bumpversion>=0.5.3,<1.0.0']
     },
     license='MIT license',
     zip_safe=False,


### PR DESCRIPTION
This PR:
    - moves requirements from requirements.txt to setup.py.
    - Fixes circleci workflow/job/yaml issues